### PR TITLE
Update Gemfile dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,30 +7,30 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    bigdecimal (1.4.3)
-    diff-lcs (1.3)
-    rake (10.5.0)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    bigdecimal (3.2.2)
+    diff-lcs (1.6.2)
+    rake (13.3.0)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.0)
+  bundler (>= 2.0)
   crypto_formatter!
-  rake (~> 10.0)
+  rake (~> 13.0)
   rspec (~> 3.0)
 
 BUNDLED WITH

--- a/crypto_formatter.gemspec
+++ b/crypto_formatter.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'bigdecimal'
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", ">= 2.0"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
## Summary

This PR updates the Gemfile dependencies to their latest versions, addressing security vulnerabilities and ensuring compatibility with modern Ruby versions.

## Changes Made

### Gemspec Updates
- Updated `rake` constraint from `~> 10.0` to `~> 13.0`
- Updated `bundler` constraint from `~> 2.0` to `>= 2.0` for better flexibility

### Dependency Updates
- **rake**: `10.5.0` → `13.3.0`
- **bigdecimal**: `1.4.3` → `3.2.2`
- **rspec**: `3.8.0` → `3.13.1`
- **rspec-core**: `3.8.0` → `3.13.5`
- **rspec-expectations**: `3.8.2` → `3.13.5`
- **rspec-mocks**: `3.8.0` → `3.13.5`
- **rspec-support**: `3.8.0` → `3.13.4`
- **diff-lcs**: `1.3` → `1.6.2`

## Benefits

1. **Security**: Addresses potential security vulnerabilities in outdated dependencies
2. **Compatibility**: Ensures compatibility with modern Ruby versions (currently using Ruby 3.1.2)
3. **Bug Fixes**: Includes bug fixes and improvements from newer gem versions
4. **Maintenance**: Keeps the project up-to-date with current Ruby ecosystem standards

## Testing

- All existing tests continue to pass with the updated dependencies
- Bundle install and update operations complete successfully
- No breaking changes detected in the updated versions

## Notes

- The `bundler` constraint was changed from `~> 2.0` to `>= 2.0` to allow for future bundler updates
- All version constraints remain compatible with the existing codebase
- GitHub detected 2 moderate vulnerabilities on the default branch, which these updates should help address

@longhoangwkm can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f2997d1d8af84522b1d0aa3c61e87afc)