### PR TITLE
Update bigdecimal gem to version 3.2.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,12 @@ PATH
   remote: .
   specs:
     crypto_formatter (0.1.0)
-      bigdecimal
+      bigdecimal (~> 3.2.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    bigdecimal (1.4.3)
+    bigdecimal (3.2.2)
     diff-lcs (1.3)
     rake (10.5.0)
     rspec (3.8.0)
@@ -34,4 +34,4 @@ DEPENDENCIES
   rspec (~> 3.0)
 
 BUNDLED WITH
-   2.0.1
+   2.6.9

--- a/crypto_formatter.gemspec
+++ b/crypto_formatter.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'bigdecimal'
+  spec.add_dependency 'bigdecimal', '~> 3.2.2'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
## Description
This PR updates the bigdecimal gem from version 1.4.3 to the latest version 3.2.2.

## Changes
- Updated the gemspec file to specify bigdecimal version ~> 3.2.2
- Updated Gemfile.lock with the new dependency version
- Bundler version was also updated from 2.0.1 to 2.6.9 during the update process

## Testing
- Ran the test suite to ensure compatibility with the new version
- The existing test failure is unrelated to this update (it's a placeholder test that deliberately fails)

## Benefits
- Security improvements
- Performance enhancements
- Access to new features in the latest bigdecimal version

@longhoangwkm can click here to [continue refining the PR](https://app.all-hands.dev/conversations/008e28c7ab94478bb522857449f2a479)