### PR TITLE
Add fiat currency formatting functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # CryptoFormatter
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/crypto_formatter`. To experiment with that code, run `bin/console` for an interactive prompt.
-
-TODO: Delete this and the text above, and describe your gem
+A Ruby gem that provides convenient number formatting methods for both cryptocurrency and fiat currency values. Easily format numbers as Bitcoin satoshis, tokens, or various fiat currencies with proper symbols and formatting.
 
 ## Installation
 
@@ -22,12 +20,76 @@ Or install it yourself as:
 
 ## Usage
 
-```ruby
-  3.to_token
-  3.to_token(format: 8)
+### Cryptocurrency Formatting
 
-  "0.00000003"
+```ruby
+# Convert to Bitcoin satoshis
+1.to_satoshi          # => 100000000
+0.5.to_satoshi        # => 50000000
+
+# Convert satoshis to token format
+100000000.to_token    # => "1.0"
+50000000.to_token     # => "0.5"
+
+# Custom token format (decimal places)
+1000.to_token(format: 3)  # => "1.0"
+500.to_token(format: 3)   # => "0.5"
 ```
+
+### Fiat Currency Formatting
+
+```ruby
+# Basic USD formatting (default)
+1234.56.to_currency   # => "$1,234.56"
+1000000.to_currency   # => "$1,000,000.00"
+
+# Different currencies
+1234.56.to_currency(currency: 'EUR')  # => "€1,234.56"
+1234.56.to_currency(currency: 'GBP')  # => "£1,234.56"
+1234.56.to_currency(currency: 'JPY', precision: 0)  # => "¥1,235"
+
+# Specific currency methods
+1234.56.to_usd        # => "$1,234.56"
+1234.56.to_eur        # => "€1,234.56"
+1234.56.to_gbp        # => "£1,234.56"
+1234.56.to_jpy        # => "¥1,235" (no decimals by default)
+1234.56.to_cad        # => "C$1,234.56"
+1234.56.to_aud        # => "A$1,234.56"
+1234.56.to_chf        # => "CHF 1,234.56"
+
+# Custom precision
+1234.567.to_currency(precision: 3)  # => "$1,234.567"
+1234.567.to_currency(precision: 1)  # => "$1,234.6"
+1234.567.to_currency(precision: 0)  # => "$1,235"
+
+# Custom delimiters and separators
+1234.56.to_currency(delimiter: '.', separator: ',')  # => "$1.234,56"
+1234567.89.to_currency(delimiter: ' ')               # => "$1 234 567.89"
+
+# Works with both integers and floats
+1234.to_currency      # => "$1,234.00"
+1234.56.to_currency   # => "$1,234.56"
+```
+
+### Supported Currencies
+
+The gem supports the following currencies with proper symbols:
+
+- **USD** ($) - US Dollar
+- **EUR** (€) - Euro
+- **GBP** (£) - British Pound
+- **JPY** (¥) - Japanese Yen
+- **CAD** (C$) - Canadian Dollar
+- **AUD** (A$) - Australian Dollar
+- **CHF** (CHF) - Swiss Franc
+- **SEK** (kr) - Swedish Krona
+- **NOK** (kr) - Norwegian Krone
+- **DKK** (kr) - Danish Krone
+- **HKD** (HK$) - Hong Kong Dollar
+- **SGD** (S$) - Singapore Dollar
+- **NZD** (NZ$) - New Zealand Dollar
+
+For unsupported currencies, the currency code will be appended after the formatted number.
 
 ## Development
 

--- a/lib/core_extensions/number/currency.rb
+++ b/lib/core_extensions/number/currency.rb
@@ -1,12 +1,97 @@
 module CoreExtensions
   module Number
     module Currency
+      # Crypto currency methods
       def to_satoshi
         (self * 1e8).to_i
       end
 
       def to_token(format: 8)
         (self.to_i / (10**format).to_f).to_d.to_s('F')
+      end
+
+      # Fiat currency formatting methods
+      def to_currency(currency: 'USD', precision: 2, delimiter: ',', separator: '.')
+        formatted_number = format_number(self, precision: precision, delimiter: delimiter, separator: separator)
+        currency_symbol = get_currency_symbol(currency)
+        
+        case currency.upcase
+        when 'USD', 'CAD', 'AUD', 'HKD', 'SGD', 'NZD'
+          "#{currency_symbol}#{formatted_number}"
+        when 'EUR', 'GBP', 'JPY', 'CHF', 'SEK', 'NOK', 'DKK'
+          "#{currency_symbol}#{formatted_number}"
+        else
+          "#{formatted_number} #{currency.upcase}"
+        end
+      end
+
+      def to_usd(precision: 2)
+        to_currency(currency: 'USD', precision: precision)
+      end
+
+      def to_eur(precision: 2)
+        to_currency(currency: 'EUR', precision: precision)
+      end
+
+      def to_gbp(precision: 2)
+        to_currency(currency: 'GBP', precision: precision)
+      end
+
+      def to_jpy(precision: 0)
+        to_currency(currency: 'JPY', precision: precision)
+      end
+
+      def to_cad(precision: 2)
+        to_currency(currency: 'CAD', precision: precision)
+      end
+
+      def to_aud(precision: 2)
+        to_currency(currency: 'AUD', precision: precision)
+      end
+
+      def to_chf(precision: 2)
+        to_currency(currency: 'CHF', precision: precision)
+      end
+
+      private
+
+      def format_number(number, precision: 2, delimiter: ',', separator: '.')
+        # Convert to float and round to specified precision
+        rounded = number.to_f.round(precision)
+        
+        # Split into integer and decimal parts
+        integer_part, decimal_part = rounded.to_s.split('.')
+        
+        # Add thousand separators to integer part
+        integer_part = integer_part.reverse.gsub(/(\d{3})(?=\d)/, "\\1#{delimiter}").reverse
+        
+        # Format final number
+        if precision > 0
+          decimal_part ||= '0'
+          decimal_part = decimal_part.ljust(precision, '0')[0, precision]
+          "#{integer_part}#{separator}#{decimal_part}"
+        else
+          integer_part
+        end
+      end
+
+      def get_currency_symbol(currency)
+        symbols = {
+          'USD' => '$',
+          'EUR' => '€',
+          'GBP' => '£',
+          'JPY' => '¥',
+          'CAD' => 'C$',
+          'AUD' => 'A$',
+          'CHF' => 'CHF ',
+          'SEK' => 'kr',
+          'NOK' => 'kr',
+          'DKK' => 'kr',
+          'HKD' => 'HK$',
+          'SGD' => 'S$',
+          'NZD' => 'NZ$'
+        }
+        symbols[currency.upcase] || currency.upcase
       end
     end
   end
@@ -17,5 +102,6 @@ if RUBY_VERSION.to_f < 2.4
   Float.include CoreExtensions::Number::Currency
 else
   Integer.include CoreExtensions::Number::Currency
+  Float.include CoreExtensions::Number::Currency
 end
 

--- a/spec/crypto_formatter_spec.rb
+++ b/spec/crypto_formatter_spec.rb
@@ -3,7 +3,114 @@ RSpec.describe CryptoFormatter do
     expect(CryptoFormatter::VERSION).not_to be nil
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  describe "crypto currency formatting" do
+    it "converts to satoshi" do
+      expect(1.to_satoshi).to eq(100_000_000)
+      expect(0.5.to_satoshi).to eq(50_000_000)
+    end
+
+    it "converts to token with default format" do
+      expect(100_000_000.to_token).to eq("1.0")
+      expect(50_000_000.to_token).to eq("0.5")
+    end
+
+    it "converts to token with custom format" do
+      expect(1000.to_token(format: 3)).to eq("1.0")
+      expect(500.to_token(format: 3)).to eq("0.5")
+    end
+  end
+
+  describe "fiat currency formatting" do
+    describe "#to_currency" do
+      it "formats USD by default" do
+        expect(1234.56.to_currency).to eq("$1,234.56")
+        expect(1000000.to_currency).to eq("$1,000,000.00")
+      end
+
+      it "formats different currencies" do
+        expect(1234.56.to_currency(currency: 'EUR')).to eq("€1,234.56")
+        expect(1234.56.to_currency(currency: 'GBP')).to eq("£1,234.56")
+        expect(1234.56.to_currency(currency: 'JPY', precision: 0)).to eq("¥1,235")
+      end
+
+      it "handles custom precision" do
+        expect(1234.567.to_currency(precision: 3)).to eq("$1,234.567")
+        expect(1234.567.to_currency(precision: 1)).to eq("$1,234.6")
+        expect(1234.567.to_currency(precision: 0)).to eq("$1,235")
+      end
+
+      it "handles custom delimiters and separators" do
+        expect(1234.56.to_currency(delimiter: '.', separator: ',')).to eq("$1.234,56")
+        expect(1234567.89.to_currency(delimiter: ' ')).to eq("$1 234 567.89")
+      end
+
+      it "handles unknown currencies" do
+        expect(1234.56.to_currency(currency: 'XYZ')).to eq("1,234.56 XYZ")
+      end
+    end
+
+    describe "specific currency methods" do
+      it "formats USD" do
+        expect(1234.56.to_usd).to eq("$1,234.56")
+        expect(1234.567.to_usd(precision: 3)).to eq("$1,234.567")
+      end
+
+      it "formats EUR" do
+        expect(1234.56.to_eur).to eq("€1,234.56")
+        expect(1234.567.to_eur(precision: 1)).to eq("€1,234.6")
+      end
+
+      it "formats GBP" do
+        expect(1234.56.to_gbp).to eq("£1,234.56")
+      end
+
+      it "formats JPY with no decimals by default" do
+        expect(1234.56.to_jpy).to eq("¥1,235")
+        expect(1234.56.to_jpy(precision: 2)).to eq("¥1,234.56")
+      end
+
+      it "formats CAD" do
+        expect(1234.56.to_cad).to eq("C$1,234.56")
+      end
+
+      it "formats AUD" do
+        expect(1234.56.to_aud).to eq("A$1,234.56")
+      end
+
+      it "formats CHF" do
+        expect(1234.56.to_chf).to eq("CHF 1,234.56")
+      end
+    end
+
+    describe "edge cases" do
+      it "handles zero values" do
+        expect(0.to_currency).to eq("$0.00")
+        expect(0.to_usd).to eq("$0.00")
+      end
+
+      it "handles negative values" do
+        expect(-1234.56.to_currency).to eq("$-1,234.56")
+        expect(-1234.56.to_eur).to eq("€-1,234.56")
+      end
+
+      it "handles very large numbers" do
+        expect(1234567890.12.to_currency).to eq("$1,234,567,890.12")
+      end
+
+      it "handles very small numbers" do
+        expect(0.01.to_currency).to eq("$0.01")
+        expect(0.001.to_currency(precision: 3)).to eq("$0.001")
+      end
+
+      it "works with integers" do
+        expect(1234.to_currency).to eq("$1,234.00")
+        expect(1234.to_usd).to eq("$1,234.00")
+      end
+
+      it "works with floats" do
+        expect(1234.56.to_currency).to eq("$1,234.56")
+        expect(1234.56.to_eur).to eq("€1,234.56")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Overview

This PR adds comprehensive fiat currency formatting functionality to the `crypto_formatter` gem, extending its capabilities beyond cryptocurrency formatting to support major world currencies.

## Features Added

### 🌍 Multi-Currency Support
- **13 major currencies** with proper symbols and formatting:
  - USD ($), EUR (€), GBP (£), JPY (¥)
  - CAD (C$), AUD (A$), CHF (CHF)
  - SEK (kr), NOK (kr), DKK (kr)
  - HKD (HK$), SGD (S$), NZD (NZ$)

### 🎯 Flexible Formatting Options
- **Custom precision**: Control decimal places (0-n digits)
- **Custom delimiters**: Thousand separators (comma, period, space, etc.)
- **Custom separators**: Decimal point separators
- **Automatic rounding**: Proper rounding for specified precision

### 🚀 Convenient Methods
- **Generic method**: `to_currency(currency: 'USD', precision: 2, delimiter: ',', separator: '.')`
- **Currency-specific methods**: `to_usd`, `to_eur`, `to_gbp`, `to_jpy`, `to_cad`, `to_aud`, `to_chf`
- **Smart defaults**: JPY defaults to 0 decimal places, others to 2

### 🔧 Robust Implementation
- Works with both `Integer` and `Float` classes
- Handles edge cases: zero, negative numbers, very large/small numbers
- Maintains backward compatibility with existing crypto functionality

## Usage Examples

```ruby
# Basic formatting
1234.56.to_currency          # => "$1,234.56"
1234.56.to_eur               # => "€1,234.56"
1234.56.to_jpy               # => "¥1,235"

# Custom formatting
1234.567.to_currency(precision: 3)                    # => "$1,234.567"
1234.56.to_currency(delimiter: '.', separator: ',')  # => "$1.234,56"

# Multiple currencies
1234.56.to_usd               # => "$1,234.56"
1234.56.to_gbp               # => "£1,234.56"
1234.56.to_cad               # => "C$1,234.56"
```

## Testing

- ✅ Comprehensive test suite covering all formatting scenarios
- ✅ Edge case testing (zero, negative, large numbers)
- ✅ Cross-platform compatibility (Integer/Float support)
- ✅ Backward compatibility with existing crypto methods

## Documentation

- 📚 Updated README with detailed usage examples
- 📚 Complete list of supported currencies
- 📚 Formatting options documentation

## Files Changed

- `lib/core_extensions/number/currency.rb` - Core implementation
- `spec/crypto_formatter_spec.rb` - Comprehensive test coverage
- `README.md` - Updated documentation and examples

This enhancement makes the gem more versatile for financial applications that need both cryptocurrency and fiat currency formatting capabilities.

@longhoangwkm can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f7e295e75a0b40189c6c5f82f50a194b)